### PR TITLE
Suspend/resume AudioContext to reduce CPU usage. Related to #115

### DIFF
--- a/lib/common/sound_effects.js
+++ b/lib/common/sound_effects.js
@@ -57,7 +57,10 @@ function SoundEffects () {
 
   this.waveform = "square";
   this.scale = this.makeScale(harmonicMinor, 220, 15);
+  this.suspendTimeout = null;
   console.log("sound effects initialized");
+  // Prevent CPU usage by suspending everything until we need it.
+  this.context.suspend();
 }
 
 /**
@@ -67,7 +70,6 @@ function SoundEffects () {
  * @param {number} offset
  */
 SoundEffects.prototype.playNote = function (type, frequency, noteDuration, offset) {
-  var osc;
   if (!this.context) {
     return;
   }
@@ -75,16 +77,32 @@ SoundEffects.prototype.playNote = function (type, frequency, noteDuration, offse
     console.debug("sound disabled. not playing", frequency, "for", noteDuration);
     return;
   }
-  console.debug("playing", frequency, "for", noteDuration);
-  osc = this.context.createOscillator();
-  offset = offset || 0;
 
-  osc.type = type;
-  osc.frequency.value = frequency;
+  const play = () => {
+    console.debug("playing", frequency, "for", noteDuration);
+    const osc = this.context.createOscillator();
+    offset = offset || 0;
 
-  osc.connect(this.panner);
-  osc.start(this.context.currentTime + offset);
-  osc.stop(this.context.currentTime + offset + noteDuration);
+    osc.type = type;
+    osc.frequency.value = frequency;
+
+    osc.connect(this.panner);
+    osc.start(this.context.currentTime + offset);
+    osc.stop(this.context.currentTime + offset + noteDuration);
+  };
+
+  clearTimeout(this.suspendTimeout);
+  if (this.context.state === 'running') {
+    play();
+    return;
+  }
+  this.context.resume().then(() => {
+    clearTimeout(this.suspendTimeout);
+    play();
+    this.suspendTimeout = setTimeout(() => {
+      this.context.suspend();
+    }, noteDuration + offset + 10);
+  });
 };
 
 /**


### PR DESCRIPTION
This doesn't totally fix the bug, since `context.suspend()` doesn't seem to actually do anything. Still, it's better than what was there before.
