### PR TITLE
Fixing shared terminals (via Term3) when username contains a period

### DIFF
--- a/lib/terminal_manager.js
+++ b/lib/terminal_manager.js
@@ -28,7 +28,7 @@ TerminalManager.prototype.send_create_term = function (t) {
 };
 
 TerminalManager.prototype.nameForTerm = function (term) {
-  return `atom-${this.username}-${term.id}-${Math.floor(Math.random() * 10000)}`;
+  return `atom-${this.username.replace('.','-')}-${term.id}-${Math.floor(Math.random() * 10000)}`;
 };
 
 TerminalManager.prototype.on_floobits = function(username, floobits_terms) {


### PR DESCRIPTION
Found a bug yesterday trying to share terminals in Atom, identified with developer tools after terminal would not appear to share (and Floobits chat was saying something to the effect of "Terminal names may only contain letters, numbers, hyphens, and underscores"). After digging deeper, it appears that since Floobits included the username in the terminal title, and usernames could contain periods, the server was rejecting the invalid names.

This has fixed it on my system (Win7, Up-to-date Atom, Term3, & Floobits).